### PR TITLE
Update create_logit_lens.py

### DIFF
--- a/scripts/logit_lens/create_logit_lens.py
+++ b/scripts/logit_lens/create_logit_lens.py
@@ -5,7 +5,7 @@ from PIL import Image
 from tqdm import tqdm
 
 current_dir = os.path.dirname(os.path.abspath(__file__))
-src_path = os.path.join(current_dir, '..', '..', 'src')
+src_path = os.path.join(current_dir, '..', '..')
 sys.path.append(src_path)
 
 from src.HookedLVLM import HookedLVLM


### PR DESCRIPTION
Without 'src' all work perfect! How I understand the script doesn't work on my device, because src_path ended in .../src, which in line 11 caused an error because the compiler searched for the HookedLVLM file at .../src/src/.